### PR TITLE
リポジトリ分析用基盤の実装に向けた戦略の叩き台をドキュメント化

### DIFF
--- a/docs/API_STRATEGY.ja.md
+++ b/docs/API_STRATEGY.ja.md
@@ -4,7 +4,12 @@
 
 English version: [API_STRATEGY.md](API_STRATEGY.md)
 
-関連戦略: [STRATEGY.ja.md](STRATEGY.ja.md)
+関連文書:
+
+- [STRATEGY.ja.md](STRATEGY.ja.md)
+- [CONCEPTS.ja.md](CONCEPTS.ja.md)
+- [ARCHITECTURE.ja.md](ARCHITECTURE.ja.md)
+- [MIGRATION.ja.md](MIGRATION.ja.md)
 
 この文書は、軽量な program-structure engine としての Astars の API 戦略を定義する。目的は、downstream の `astars-*` package が安心して依存できる表面を作りつつ、parser 固有の詳細や application-specific な判断を public API から切り離すことである。
 
@@ -111,7 +116,7 @@ for node in unit.walk():
 
 ```python
 functions = unit.find(kind="FunctionDef")
-node = unit.node_at(offset=42)
+node = unit.node_at(byte_offset=42)
 ```
 
 query API は、一般的な分析 workflow をカバーしつつ、domain-specific になりすぎないようにする。
@@ -128,23 +133,170 @@ node から source への mapping は、first-class public workflow として扱
 ### Source-Aware Operation を組み立てる
 
 ```python
-edit = unit.remove(node)
+edit = unit.edit.delete(node)
 new_source = edit.apply()
 ```
 
 core は generic edit primitive を提供してよい。ただし、どの node を編集対象にするかという domain-specific な判断は Astars core の外に置く。
 
+この workflow は重要だが、最初に固定する public API には含めない。まず parse、inspect、query、source mapping を安定させ、その後に edit primitive を追加する。
+
+## Initial Public API
+
+この節は、`MIGRATION.ja.md` の Phase 1 で最初に実装・固定する public API を定義する。
+
+v0 の public API は、source code を parse し、AST-like node を inspect/query し、node を source span に戻すところまでを対象にする。source-aware edit primitive は次段階の API として扱う。
+
+### v0 で固定する API
+
+v0 では、次の名前を `astars` 直下から import できるようにする。
+
+- `astars.parse_file`
+- `astars.parse_str`
+- `astars.parse_bytes`
+- `astars.SourceUnit`
+- `astars.SourceSpan`
+- `astars.Diagnostic`
+- `astars.AstarsError`
+- `astars.UnsupportedLanguageError`
+- `astars.ParserUnavailableError`
+- `astars.__version__`
+
+AST node の concrete class 名は v0 では強く固定しない。ただし、public node interface は固定する。
+
+### Parse Functions
+
+最初の parse API は、次の形を基本とする。
+
+```python
+unit = astars.parse_file(path, *, lang, encoding="utf-8")
+unit = astars.parse_str(source, *, lang, path=None)
+unit = astars.parse_bytes(source_bytes, *, lang, path=None)
+```
+
+方針:
+
+- `lang` は keyword-only かつ必須にする
+- file extension からの language 推定は v0 では必須機能にしない
+- 汎用的な `options` bag は v0 では公開しない
+- `path` は source location を保持するための任意 metadata として扱う
+- 3 つの parse function は同じ `SourceUnit` を返す
+
+`options` は便利だが、意味が曖昧なまま public API に入れると将来の互換性を壊しやすい。必要な option が明確になった時点で、名前付き引数または extension API として追加する。
+
+### SourceUnit Interface
+
+`SourceUnit` は、1つの source input を parse した結果全体を表す public handle として採用する。
+
+v0 で固定する property / method:
+
+- `unit.lang`
+- `unit.path`
+- `unit.source`
+- `unit.root`
+- `unit.diagnostics`
+- `unit.walk(kind=None)`
+- `unit.find(kind=None)`
+- `unit.node_at(byte_offset)`
+- `unit.span_of(node)`
+- `unit.source_of(node)`
+
+方針:
+
+- `unit.root` は AST-like root node を返す
+- `unit.walk()` は `unit.root` からの depth-first traversal を返す
+- `unit.find(kind="FunctionDef")` は kind による最小 query として始める
+- `unit.node_at(byte_offset)` は byte offset から最も対応する node を返す
+- `unit.span_of(node)` は `SourceSpan` または `None` を返す
+- `unit.source_of(node)` は node に対応する source text を返す
+
+query 条件は、最初は `kind` に絞る。`role`、`name`、predicate、selector DSL は、実際の downstream use case が見えてから追加する。
+
+### Public Node Interface
+
+v0 の node object は、少なくとも次の属性を持つ。
+
+- `node.kind`
+- `node.id`
+- `node.children`
+- `node.role`
+- `node.value`
+
+必須:
+
+- `kind`
+- `id`
+- `children`
+
+任意:
+
+- `role`
+- `value`
+
+`node.id` は、1つの `SourceUnit` の中で node を識別するための ID とする。v0 では、edit をまたいだ永続 ID や Astars version をまたいだ stable ID は保証しない。
+
+### SourceSpan Interface
+
+`SourceSpan` は、source code 上の範囲を表す public object として採用する。
+
+v0 で固定する属性:
+
+- `span.start_byte`
+- `span.end_byte`
+- `span.start_point`
+- `span.end_point`
+
+方針:
+
+- byte offset を canonical representation とする
+- `start_point` / `end_point` は 0-based の `(line, column)` とする
+- line は 0-based line number とする
+- column は byte column を基本とし、Unicode column 表示は別 helper の候補とする
+
+人間向け表示や review comment では 1-based line number が必要になることがある。その変換は helper として提供してよいが、engine 内部と public span object の基準は 0-based に揃える。
+
+### Diagnostics Interface
+
+`Diagnostic` は、parse や normalization の問題を表す public object として扱う。
+
+v0 で固定する属性:
+
+- `diagnostic.severity`
+- `diagnostic.message`
+- `diagnostic.span`
+
+方針:
+
+- syntax error のように parser が recovery できる問題は、可能な限り `unit.diagnostics` に載せる
+- unsupported language や parser dependency missing は exception として扱う
+- `span` が特定できない diagnostic では `span=None` を許容する
+
+### v0 では固定しない API
+
+次の API は重要だが、v0 の固定対象から外す。
+
+- CST の stable public API
+- `RawSyntaxNode` の public API
+- parser adapter contract
+- language extension API
+- edit primitive
+- selector DSL
+- semantic analysis API
+- legacy `AParser` / `APruner` / `ATraverser`
+
+これらは extension-level または次段階の API として設計する。
+
 ## Proposed Public Surface
 
-この節は提案である。名前は API が安定するまで draft-level とする。
+この節は、v0 の後に拡張する候補を含む提案である。`Initial Public API` と矛盾する場合は、`Initial Public API` を優先する。
 
 ### Top-Level Functions
 
 Astars は、小さな top-level parse API を提供する。
 
-- `astars.parse_file(path, *, lang, encoding=None, options=None)`
-- `astars.parse_str(source, *, lang, encoding="utf-8", options=None)`
-- `astars.parse_bytes(source_bytes, *, lang, options=None)`
+- `astars.parse_file(path, *, lang, encoding="utf-8")`
+- `astars.parse_str(source, *, lang, path=None)`
+- `astars.parse_bytes(source_bytes, *, lang, path=None)`
 
 これらの関数は、同じ種類の result object を返す。
 
@@ -152,11 +304,12 @@ Astars は、小さな top-level parse API を提供する。
 
 parse result は、高レベルな source unit object であるべきである。
 
-現在の実装では `ParseResult` と呼ぶかもしれないが、長期的な概念としては `SourceUnit` に近い。つまり、1 つの source input と、その構造、mapping、diagnostics をまとめた単位である。
+parse result は `SourceUnit` と呼ぶ。これは、1 つの source input と、その構造、mapping、diagnostics をまとめた単位である。
 
 必要な public capability:
 
 - `unit.lang`
+- `unit.path`
 - `unit.source`
 - `unit.root`
 - `unit.diagnostics`
@@ -188,14 +341,10 @@ span は少なくとも次を持つ。
 
 - `start_byte`
 - `end_byte`
-
-必要に応じて次を持ってよい。
-
 - `start_point`
 - `end_point`
-- `encoding`
 
-byte offset を canonical representation とする。line/column helper は提供してよいが、0-based か 1-based かは明示的に文書化する。
+byte offset を canonical representation とする。`start_point` / `end_point` は 0-based の `(line, column)` とし、column は byte column を基本とする。
 
 ### Diagnostics
 
@@ -229,7 +378,7 @@ downstream package が依存してよいもの:
 - AST node interface
 - source span interface
 - public query/traversal helpers
-- documented generic edit primitives
+- edit API 導入後に文書化された generic edit primitives
 
 ### Extension-Level
 
@@ -336,7 +485,7 @@ def collect_metrics(unit: astars.SourceUnit) -> dict:
     }
 ```
 
-result object の最終名が `SourceUnit` でない場合、この例は最終的な public name に合わせて更新する。
+downstream package は、可能であれば source path や raw source ではなく `SourceUnit` を受け取る形にする。
 
 ## Non-Goals
 
@@ -351,14 +500,13 @@ API は次のものを公開しない。
 
 ## Open Questions
 
-- primary result object の名前は `ParseResult`, `SourceUnit`, `Program`, あるいは別名のどれにするか
 - `CST` は stable public API に含めるべきか
 - `RawSyntaxNode` は public, extension-level, internal のどれに置くべきか
 - traversal は result object の method、standalone function、あるいは両方として公開するべきか
 - edit primitive は text を直接返すべきか、edit plan を返すべきか、新しい parsed source unit を返すべきか
 - language extension API は `1.0` 前にどこまで stable にするべきか
-- public API の line/column position は 0-based と 1-based のどちらにするべきか
 - `stable_id` の保証が限定的な場合、名前を変えるべきか
+- Unicode code point / grapheme cluster ベースの column 表示を public helper として提供するべきか
 
 ## 成功条件
 

--- a/docs/API_STRATEGY.ja.md
+++ b/docs/API_STRATEGY.ja.md
@@ -1,0 +1,372 @@
+# Astars API 戦略
+
+ステータス: draft
+
+English version: [API_STRATEGY.md](API_STRATEGY.md)
+
+関連戦略: [STRATEGY.ja.md](STRATEGY.ja.md)
+
+この文書は、軽量な program-structure engine としての Astars の API 戦略を定義する。目的は、downstream の `astars-*` package が安心して依存できる表面を作りつつ、parser 固有の詳細や application-specific な判断を public API から切り離すことである。
+
+## 目的
+
+Astars API は、core engine と downstream analysis module の間の契約である。
+
+downstream package は、この API を通じて source code を parse し、program structure を inspect し、node を source span に戻し、generic な source-aware operation を組み立てられるべきである。
+
+API は次の性質を持つべきである。
+
+- 小さく、学びやすい
+- downstream package が依存できる程度に安定している
+- source mapping を明示的に扱う
+- analysis meaning について中立である
+- public / extension-level / internal の境界が明確である
+
+## 想定ユーザー
+
+### Downstream Package Authors
+
+`astars-metrics`, `astars-code-review`, `astars-pruning`, `astars-llm-eval` などを書くユーザー。
+
+この層のユーザーには安定した契約が必要である。通常の分析 workflow では、adapter internals、rule builders、parser objects を import する必要がない状態を目指す。
+
+### Research Prototype Authors
+
+notebook、script、実験コードで source code を素早く parse、inspect、query、transform したいユーザー。
+
+この層のユーザーには、単純な top-level function と読みやすい data structure が必要である。
+
+### Language Extension Authors
+
+別言語のサポートを追加したいユーザー。
+
+この層には、adapter、rule registry、normalization logic のための extension API が必要になる。ただし、それは stable public API とは分けて文書化する。
+
+### Engine Contributors
+
+Astars 自体を実装する開発者。
+
+この層のユーザーは internal module に触ることがある。ただし、repository に存在する module がそのまま implicit public API になるべきではない。
+
+## API レイヤー
+
+Astars は、概念的に 3 つの API レイヤーを持つ。
+
+### Stable Public API
+
+stable public API は、downstream package が通常依存してよい API である。
+
+`astars` 直下、または文書化された public submodule から import できるようにする。
+
+例:
+
+- `astars.parse_file`
+- `astars.parse_str`
+- `astars.parse_bytes`
+- public result object
+- public AST node interface
+- public source span interface
+- public query/traversal helpers
+
+### Extension API
+
+extension API は、言語追加や normalization behavior の変更のための API である。
+
+adapter contract、rule registry contract、language support hook などを含む可能性がある。stable public API より速く変化してよいが、contributor が使える程度には文書化する。
+
+### Internal API
+
+internal API は実装詳細である。
+
+parser-specific object、raw tree-sitter node、rule builder internals、cache internals は stable ではない。downstream package は、意図的に破壊的変更を受け入れる場合を除き、これらに依存しない。
+
+## Primary Workflows
+
+public API は、次の workflow を中心に設計する。
+
+### Source を Parse する
+
+```python
+import astars
+
+unit = astars.parse_file("example.py", lang="python")
+unit = astars.parse_str("x = 1\n", lang="python")
+unit = astars.parse_bytes(b"x = 1\n", lang="python")
+```
+
+parse result は、source、AST、mapping、diagnostics、query helper を持つ main handle になるべきである。
+
+### Structure を Inspect する
+
+```python
+root = unit.root
+
+for node in unit.walk():
+    print(node.kind)
+```
+
+ユーザーは、tree-sitter object に依存せずに AST-like structure を inspect できるべきである。
+
+### Node を Query する
+
+```python
+functions = unit.find(kind="FunctionDef")
+node = unit.node_at(offset=42)
+```
+
+query API は、一般的な分析 workflow をカバーしつつ、domain-specific になりすぎないようにする。
+
+### Node を Source に戻す
+
+```python
+span = unit.span_of(node)
+source = unit.source_of(node)
+```
+
+node から source への mapping は、first-class public workflow として扱う。
+
+### Source-Aware Operation を組み立てる
+
+```python
+edit = unit.remove(node)
+new_source = edit.apply()
+```
+
+core は generic edit primitive を提供してよい。ただし、どの node を編集対象にするかという domain-specific な判断は Astars core の外に置く。
+
+## Proposed Public Surface
+
+この節は提案である。名前は API が安定するまで draft-level とする。
+
+### Top-Level Functions
+
+Astars は、小さな top-level parse API を提供する。
+
+- `astars.parse_file(path, *, lang, encoding=None, options=None)`
+- `astars.parse_str(source, *, lang, encoding="utf-8", options=None)`
+- `astars.parse_bytes(source_bytes, *, lang, options=None)`
+
+これらの関数は、同じ種類の result object を返す。
+
+### Primary Result Object
+
+parse result は、高レベルな source unit object であるべきである。
+
+現在の実装では `ParseResult` と呼ぶかもしれないが、長期的な概念としては `SourceUnit` に近い。つまり、1 つの source input と、その構造、mapping、diagnostics をまとめた単位である。
+
+必要な public capability:
+
+- `unit.lang`
+- `unit.source`
+- `unit.root`
+- `unit.diagnostics`
+- `unit.walk(...)`
+- `unit.find(...)`
+- `unit.node_at(...)`
+- `unit.span_of(node)`
+- `unit.source_of(node)`
+
+通常の workflow では、parser-specific tree にアクセスする必要がない設計にする。
+
+### AST Node Interface
+
+AST node は、小さく安定した interface を公開する。
+
+- `node.kind`
+- `node.id` または `node.stable_id`
+- `node.role`
+- `node.value`
+- `node.children`
+
+保存方法の詳細は internal とする。Astars が内部で `anytree` を使うとしても、downstream package に `anytree` API への依存を強制しない。
+
+### Source Span Interface
+
+source span は、public API では匿名 tuple ではなく明示的な object として扱う。
+
+span は少なくとも次を持つ。
+
+- `start_byte`
+- `end_byte`
+
+必要に応じて次を持ってよい。
+
+- `start_point`
+- `end_point`
+- `encoding`
+
+byte offset を canonical representation とする。line/column helper は提供してよいが、0-based か 1-based かは明示的に文書化する。
+
+### Diagnostics
+
+syntax error を含む source を parse した場合、可能であれば常に exception を投げるのではなく、diagnostics を持つ result を返す。
+
+exception は次のような失敗に使う。
+
+- unsupported language
+- missing parser dependency
+- invalid input type
+- unrecoverable parser failure
+
+### Version Information
+
+Astars は自身の version を公開する。
+
+```python
+astars.__version__
+```
+
+downstream package は、対応する Astars engine version を宣言できるべきである。
+
+## Public vs Internal Objects
+
+### Public By Default
+
+downstream package が依存してよいもの:
+
+- top-level parse functions
+- primary result object
+- AST node interface
+- source span interface
+- public query/traversal helpers
+- documented generic edit primitives
+
+### Extension-Level
+
+文書化するが、public API より変化を許容するもの:
+
+- language adapter contracts
+- AST rule contracts
+- normalization hooks
+- language registry APIs
+
+### Internal By Default
+
+stable public API ではないもの:
+
+- tree-sitter node objects
+- tree-sitter parser objects
+- raw parser caches
+- concrete rule builder internals
+- private mapping indexes
+- vendored grammar files
+- implementation-specific tree libraries
+
+## Compatibility Strategy
+
+### Legacy Names
+
+`AParser`, `APruner`, `ATraverser` のような legacy name は、新 API を定義する中心にしない。
+
+考えられる方針:
+
+- `AParser` は、一時的な compatibility wrapper として再導入してもよい。
+- `APruner` は domain-specific pruning strategy を表すなら core の外へ移す。
+- `ATraverser` は generic traversal primitive に置き換える。
+
+新しい downstream package は、legacy `A*` API ではなく新 API を対象にする。
+
+### Breaking Changes
+
+`1.0` 以前は、engine surface を安定させる過程で breaking change が発生してよい。
+
+ただし `1.0` 以前であっても、次に影響する breaking change は文書化する。
+
+- top-level parse functions
+- result object shape
+- node interface
+- span semantics
+- language support behavior
+
+`1.0` 以降の public API change は deprecation policy に従う。
+
+## Guarantees
+
+### Source Mapping Guarantees
+
+parser が十分な情報を提供する場合、Astars は public node を source span に戻せることを保証する。
+
+node を mapping できない場合は、無効な span を黙って返すのではなく、`None` または文書化された missing span value を返す。
+
+### Stable ID Guarantees
+
+Astars は、"stable" の意味を慎重に定義する。
+
+初期保証:
+
+- node ID は 1 つの parsed source unit の中で安定している
+- 同じ source、language、Astars version、rule set であれば、可能な限り deterministic である
+
+初期には保証しないもの:
+
+- 任意の edit をまたいだ stable ID
+- Astars version をまたいだ stable ID
+- language rule の変更をまたいだ stable ID
+
+### Node Kind Guarantees
+
+node kind は、downstream analysis package が依存できる程度に安定させる。
+
+`astars-metrics` や `astars-code-review` のような package は node kind に依存する可能性があるため、public node kind の変更は API change として扱う。
+
+### Parser Isolation Guarantees
+
+通常の public workflow は、tree-sitter-specific object を必要としない。
+
+Astars が debug 用に parser data への access を提供する場合、その access は unstable または advanced として明示する。
+
+## Downstream Package Guidance
+
+downstream package は次の方針に従う。
+
+- documented public API に依存する
+- 可能な限り parsed source unit を入力として受け取る
+- parser adapter を直接 import しない
+- private node storage detail に依存しない
+- 対応する Astars version を文書化する
+
+望ましい downstream の形:
+
+```python
+import astars
+
+def collect_metrics(unit: astars.SourceUnit) -> dict:
+    return {
+        "functions": len(unit.find(kind="FunctionDef")),
+    }
+```
+
+result object の最終名が `SourceUnit` でない場合、この例は最終的な public name に合わせて更新する。
+
+## Non-Goals
+
+API は次のものを公開しない。
+
+- full semantic analysis framework
+- review decisions
+- metrics definitions
+- pruning policies
+- visualization-specific objects
+- 必須 workflow dependency としての parser-specific objects
+
+## Open Questions
+
+- primary result object の名前は `ParseResult`, `SourceUnit`, `Program`, あるいは別名のどれにするか
+- `CST` は stable public API に含めるべきか
+- `RawSyntaxNode` は public, extension-level, internal のどれに置くべきか
+- traversal は result object の method、standalone function、あるいは両方として公開するべきか
+- edit primitive は text を直接返すべきか、edit plan を返すべきか、新しい parsed source unit を返すべきか
+- language extension API は `1.0` 前にどこまで stable にするべきか
+- public API の line/column position は 0-based と 1-based のどちらにするべきか
+- `stable_id` の保証が限定的な場合、名前を変えるべきか
+
+## 成功条件
+
+API 戦略がうまく機能している状態とは、downstream package が次を実現できる状態である。
+
+1. `astars` を使って source を parse できる
+2. 文書化された API で node を traverse/query できる
+3. node を source span に戻せる
+4. parser object への直接依存を避けられる
+5. unrelated な `astars-*` package を install せずに Astars に依存できる
+6. minor engine update のたびに import を書き換えなくてよい

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -1,0 +1,405 @@
+# Astars アーキテクチャ
+
+ステータス: draft
+
+関連文書:
+
+- [STRATEGY.ja.md](STRATEGY.ja.md)
+- [API_STRATEGY.ja.md](API_STRATEGY.ja.md)
+- [CONCEPTS.ja.md](CONCEPTS.ja.md)
+- [ROADMAP.ja.md](ROADMAP.ja.md)
+
+この文書は、Astars の概念モデルを実装上の module boundary に落とすための叩き台である。現行コードをそのまま正当化する文書ではなく、`astars-engine` として安定させるべき目標アーキテクチャを示す。
+
+## Architecture Goals
+
+Astars の architecture は、次の性質を満たすことを目指す。
+
+- parser-specific API を core から隔離する
+- source mapping を core value として扱う
+- analysis-specific な判断を core に入れない
+- downstream package が依存しやすい小さな public API を持つ
+- Python reference path を安定させつつ、他言語追加の余地を残す
+- source-aware edit primitive を提供できる構造にする
+
+## Layer Overview
+
+Astars は、概念的に次の layer に分ける。
+
+```mermaid
+flowchart TB
+    Downstream["Downstream astars-* packages\nmetrics / review / pruning / llm-eval"]
+
+    subgraph Public["Public Surface"]
+        API["astars public API\nparse_file / parse_str / SourceUnit"]
+    end
+
+    subgraph Ops["Engine Operations"]
+        Query["query"]
+        Traverse["traversal"]
+        Edit["edit primitives"]
+    end
+
+    subgraph Core["Core Model"]
+        Source["SourceText / SourceSpan"]
+        Raw["RawSyntaxNode"]
+        CST["CST"]
+        AST["AST"]
+        Graph["SyntaxGraph"]
+        Diagnostics["Diagnostics"]
+    end
+
+    subgraph Lang["Language Support"]
+        Registry["language registry"]
+        Rules["AST rules"]
+        Python["python rules"]
+    end
+
+    subgraph Adapter["Adapters"]
+        ParseAdapter["parser adapters"]
+        TreeSitter["tree-sitter adapter"]
+    end
+
+    Parser["External parser infrastructure"]
+
+    Downstream --> API
+    API --> Query
+    API --> Traverse
+    API --> Edit
+    API --> Core
+    Query --> Core
+    Traverse --> Core
+    Edit --> Core
+    Core --> Lang
+    Lang --> Adapter
+    Adapter --> Parser
+```
+
+依存方向は、downstream package から Astars public API に向かい、Astars 内部では public API から engine operations / core model / language support / adapter へ向かう。adapter は外部 parser に依存してよいが、core model は parser object に依存しない。
+
+## Dependency Direction
+
+原則:
+
+- downstream package は `astars` public API に依存する
+- public API は core model と engine operations を組み合わせる
+- engine operations は core model に依存する
+- language support は adapter と core model の橋渡しをする
+- adapter は parser-specific API に依存してよい
+- core model は adapter や parser-specific object に依存しない
+- core は downstream package に依存しない
+
+依存方向を逆流させないことが、Astars を軽量 engine として保つための重要な制約である。
+
+## Proposed Package Layout
+
+移行後の package layout は、次のような形を目指す。
+
+```text
+astars/
+  __init__.py
+
+  api/
+    __init__.py
+    parse.py
+    source_unit.py
+
+  core/
+    source/
+      text.py
+      span.py
+    syntax/
+      raw.py
+    cst/
+      node.py
+      tree.py
+      builder.py
+    ast/
+      node.py
+      tree.py
+      builder.py
+    mapping/
+      syntax_graph.py
+    diagnostics/
+      diagnostic.py
+
+  operations/
+    query/
+      find.py
+      position.py
+    traversal/
+      walk.py
+    edit/
+      plan.py
+      primitives.py
+
+  languages/
+    registry.py
+    python/
+      adapter.py
+      rules/
+
+  adapters/
+    parse/
+      base.py
+      tree_sitter.py
+
+  internal/
+    ids.py
+    cache.py
+```
+
+この layout は提案であり、最終決定ではない。重要なのは、責務の境界と依存方向である。
+
+## Module Responsibilities
+
+### `astars.api`
+
+public API の入口を提供する。
+
+責務:
+
+- `parse_file`, `parse_str`, `parse_bytes` を公開する
+- `SourceUnit` を返す
+- downstream package が通常触る API を集約する
+- internal module の詳細を隠す
+
+`astars.__init__` は、`astars.api` の安定した API だけを再 export する。
+
+### `astars.core.source`
+
+`SourceText` と `SourceSpan` を扱う。
+
+責務:
+
+- source bytes/text を保持する
+- byte offset を canonical な位置表現として扱う
+- line/column 変換を提供する
+- source slice を取得する
+
+### `astars.core.syntax`
+
+parser 由来の構文情報を Astars-owned structure に変換した `RawSyntaxNode` を扱う。
+
+責務:
+
+- parser node の type / field / child relation / source range を保持する
+- CST / AST builder の入力になる
+- parser-specific object を core model に持ち込まない
+
+### `astars.core.cst`
+
+source-faithful な concrete syntax structure を扱う。
+
+責務:
+
+- source に近い構文構造を保持する
+- debugging や low-level transform の基盤になる
+- AST では失われる可能性がある構文情報を補う
+
+CST を stable public API にするかは未決定である。
+
+### `astars.core.ast`
+
+analysis-friendly な AST-like structure を扱う。
+
+責務:
+
+- downstream package が query / traversal しやすい node interface を提供する
+- function、class、statement、expression などの分析単位を表す
+- `SyntaxGraph` を通じて source に戻れる node を提供する
+
+### `astars.core.mapping`
+
+`SyntaxGraph` を扱う。
+
+責務:
+
+- AST node と raw syntax / source span の対応を保持する
+- source offset から node を解決する
+- node から source slice を取得できるようにする
+- edit primitive の対象範囲を決める
+
+### `astars.core.diagnostics`
+
+parse や normalization の診断情報を扱う。
+
+責務:
+
+- syntax error
+- unsupported syntax
+- mapping failure
+- adapter limitation
+
+実行不能なエラーと、parse result に保持できる diagnostics を分ける。
+
+### `astars.operations`
+
+engine-level の generic operation を扱う。
+
+責務:
+
+- AST traversal
+- node query
+- source position lookup
+- source extraction
+- generic edit primitive
+
+ここには metrics definition、review policy、pruning strategy のような domain-specific logic を入れない。
+
+### `astars.languages`
+
+言語固有の rule と registry を扱う。
+
+責務:
+
+- language id と adapter/rule set の対応を管理する
+- Python reference implementation を置く
+- AST rule contract を提供する
+
+`languages/python` は reference path として安定させる。
+
+### `astars.adapters`
+
+外部 parser や外部技術との接続を扱う。
+
+責務:
+
+- tree-sitter parser の呼び出し
+- parser-specific node から `RawSyntaxNode` への変換
+- parser dependency の不足や unsupported language を検出する
+
+adapter は parser-specific API に依存してよい。ただし、その依存を core model や public API に漏らさない。
+
+### `astars.internal`
+
+外部に安定 API として公開しない補助実装を置く。
+
+例:
+
+- id generation
+- cache
+- internal helper
+- compatibility shim の補助
+
+downstream package は `astars.internal` に依存してはいけない。
+
+## Data Flow
+
+parse の data flow は次の通り。
+
+```mermaid
+sequenceDiagram
+    participant User as downstream/user
+    participant API as astars.api
+    participant Adapter as parser adapter
+    participant Raw as RawSyntaxNode
+    participant Builder as CST/AST builders
+    participant Graph as SyntaxGraph
+    participant Unit as SourceUnit
+
+    User->>API: parse_file / parse_str
+    API->>Adapter: parse SourceText
+    Adapter->>Raw: convert parser nodes
+    Raw->>Builder: build CST / AST
+    Builder->>Graph: register node mappings
+    Graph->>Unit: attach mapping
+    API-->>User: SourceUnit
+```
+
+重要なのは、user が parser object を受け取らないことである。user は `SourceUnit` を通じて AST、query、source mapping、diagnostics にアクセスする。
+
+## Source Mapping Flow
+
+node から source に戻る流れは次の通り。
+
+```mermaid
+flowchart LR
+    Node["AST Node"]
+    Graph["SyntaxGraph"]
+    Span["SourceSpan"]
+    Text["SourceText"]
+    Slice["source slice"]
+    Edit["Edit primitive"]
+
+    Node --> Graph
+    Graph --> Span
+    Span --> Text
+    Text --> Slice
+    Span --> Edit
+```
+
+この flow により、downstream package は分析結果を source span に戻し、review comment、metric location、edit plan などに利用できる。
+
+## Public / Extension / Internal Boundary
+
+### Public
+
+downstream package が通常依存してよいもの:
+
+- `astars.parse_file`
+- `astars.parse_str`
+- `astars.parse_bytes`
+- `SourceUnit`
+- AST node interface
+- `SourceSpan`
+- query / traversal helpers
+- generic edit primitive
+
+### Extension-Level
+
+言語追加や advanced customization のために文書化するもの:
+
+- language registry
+- AST rule contract
+- adapter contract
+- `RawSyntaxNode`
+
+### Internal
+
+安定 API として扱わないもの:
+
+- tree-sitter parser object
+- tree-sitter node object
+- private cache
+- internal id generator
+- builder の詳細実装
+- implementation-specific tree library
+
+## Current Repository Gap
+
+現行 repository には、目標アーキテクチャとずれている箇所がある。
+
+例:
+
+- `astars/__init__.py` が public API として未整理
+- `api.py` / `engine.py` の責務が未定義
+- `usecase/` が engine operation なのか domain use case なのか曖昧
+- `adapter/edit/` が parser adapter なのか edit primitive なのか曖昧
+- `core/syntax`, `core/cst`, `core/ast` は方向性が近いが、public boundary は未整理
+- examples と README が legacy API を参照している
+
+実装整理では、まず public API と core model の境界を固定し、その後に module 名を整理する。
+
+## Migration Notes
+
+移行時の大まかな方針:
+
+1. `astars.api` と `SourceUnit` public handle を作る
+2. `parse_file`, `parse_str`, `parse_bytes` を public API として安定させる
+3. `RawSyntaxNode`, AST builder, `SyntaxGraph` の責務を `CONCEPTS.ja.md` に合わせる
+4. traversal / query / edit primitive を `operations/` に集約する
+5. domain-specific な pruning strategy は core から外す
+6. legacy `AParser` などを残す場合は thin compatibility shim とする
+
+詳細な移行手順は、別途 `MIGRATION.ja.md` で定義する。
+
+## Open Questions
+
+- `api/` package を作るか、top-level `astars/__init__.py` に集約するか
+- `core/mapping/` を独立 package にするか、`core/syntax/` に含めるか
+- `languages/` と `adapters/` の境界をどう分けるか
+- `operations/edit/` と source text editing backend の責務をどう分けるか
+- CST を public API にするか、debug/extension-level に留めるか
+- `usecase/` を廃止して `operations/` に置き換えるか
+- `internal/` package を明示的に作るか

--- a/docs/CONCEPTS.ja.md
+++ b/docs/CONCEPTS.ja.md
@@ -1,0 +1,294 @@
+# Astars 概念モデル
+
+ステータス: draft
+
+関連文書:
+
+- [STRATEGY.ja.md](STRATEGY.ja.md)
+- [API_STRATEGY.ja.md](API_STRATEGY.ja.md)
+- [USE_CASES.ja.md](USE_CASES.ja.md)
+
+この文書は、Astars の中核概念を定義する。目的は、実装名や module 構成に入る前に、Astars が扱う構造、source mapping、編集可能性の意味を揃えることである。
+
+## 基本方針
+
+Astars は、parser 固有の構文木をそのまま downstream package に渡すのではなく、分析しやすく、source に戻れる Astars-owned structure に変換する。
+
+そのために、次の概念を分けて扱う。
+
+- `SourceText`: 元 source code
+- `SourceSpan`: source code 上の範囲
+- `RawSyntaxNode`: parser 由来の構文情報を正規化した node
+- `CST`: source-faithful な具体構文構造
+- `AST`: analysis-friendly な抽象構造
+- `SyntaxGraph`: source / raw syntax / CST / AST の対応関係
+- `SourceUnit`: 1つの source input を parse した結果全体
+
+Astars の価値は、これらをばらばらに持つことではなく、分析しやすい構造と元 source への対応を同時に保つことにある。
+
+## 全体像
+
+概念的な data flow は次の通り。
+
+```mermaid
+flowchart TB
+    Source["SourceText\n元ソース"]
+    Parser["Parser\n(tree-sitter など)"]
+    Raw["RawSyntaxNode\nparser 由来の正規化構文"]
+    CST["CST\nsource-faithful tree"]
+    AST["AST\nanalysis-friendly tree"]
+    Graph["SyntaxGraph\nmapping / spans"]
+    Unit["SourceUnit\nparse result / public handle"]
+
+    Source --> Parser
+    Parser --> Raw
+    Raw --> CST
+    Raw --> AST
+    Source --> Graph
+    Raw --> Graph
+    CST --> Graph
+    AST --> Graph
+    Source --> Unit
+    AST --> Unit
+    Graph --> Unit
+```
+
+downstream package は、通常 `SourceUnit`、`AST`、`SourceSpan`、query/traversal API を使う。`RawSyntaxNode` や parser object は、通常 workflow では直接触らない。
+
+## SourceText
+
+`SourceText` は、Astars が parse する元 source code を表す。
+
+責務:
+
+- source bytes/text を保持する
+- encoding の扱いを明確にする
+- byte offset と line/column の変換を支える
+- source slice の取得を支える
+
+`SourceText` は単なる文字列ではない。Astars においては、node と source span を結びつける基準点である。
+
+### 設計メモ
+
+Astars では、byte offset を canonical representation とする。line/column は人間向け表示や diagnostics に必要だが、encoding の影響を受けるため、内部の mapping では byte range を基準にする。
+
+## SourceSpan
+
+`SourceSpan` は、source code 上の範囲を表す。
+
+最低限持つべき情報:
+
+- `start_byte`
+- `end_byte`
+
+必要に応じて持つ情報:
+
+- `start_point`
+- `end_point`
+- `encoding`
+- `source_id`
+
+`SourceSpan` は、AST node、CST node、diagnostic、edit primitive、review comment などを source に戻すための共通表現である。
+
+### 境界
+
+`SourceSpan` は「何を意味する範囲か」は判断しない。たとえば、その範囲が危険な API 呼び出しか、metric の対象か、review comment の対象かは downstream package が判断する。
+
+## RawSyntaxNode
+
+`RawSyntaxNode` は、parser 由来の構文情報を Astars 内部で扱いやすく正規化した node である。
+
+責務:
+
+- parser node の type / grammar name / field name / child relation を保持する
+- source byte range を保持する
+- parser 固有 object への直接依存を減らす
+- CST や AST を構築するための入力になる
+
+`RawSyntaxNode` は、tree-sitter node そのものではない。parser-specific object を Astars-owned data structure に写した中間表現である。
+
+### Public API としての位置づけ
+
+`RawSyntaxNode` は、初期方針では stable public API ではなく extension-level または internal に近い概念とする。
+
+downstream analysis package が通常依存すべきなのは、`RawSyntaxNode` ではなく AST-like node interface と source mapping API である。
+
+## CST
+
+`CST` は Concrete Syntax Tree を表す。
+
+Astars における CST は、source-faithful な構文構造であり、parser 由来の具体的な構文要素を保持する。
+
+責務:
+
+- source に近い構文構造を保持する
+- token、punctuation、構文上の詳細に近い情報を扱う
+- source-aware edit や debugging の基盤になる
+- AST だけでは失われる可能性がある構文情報を補う
+
+### AST との違い
+
+CST は source に忠実であることを重視する。AST は分析しやすいことを重視する。
+
+たとえば、括弧、区切り文字、構文上の wrapper node などは CST では重要だが、AST では省略または統合されることがある。
+
+### Public API としての位置づけ
+
+CST を stable public API に含めるかは未決定である。
+
+初期段階では、CST は debugging、extension、source-faithful transform のための低レベル構造として扱い、通常の downstream package は AST と `SyntaxGraph` 経由の source mapping を使う方針が自然である。
+
+## AST
+
+`AST` は、分析しやすい抽象構文構造を表す。
+
+Astars における AST は、言語固有 parser の生 node ではなく、Astars が downstream analysis のために構築する AST-like structure である。
+
+責務:
+
+- downstream analysis package が扱いやすい node kind を提供する
+- function、class、statement、expression などの分析単位を表す
+- traversal / query の主対象になる
+- `SyntaxGraph` を通じて source span に戻れる
+
+### Node Interface
+
+AST node は、小さく安定した interface を持つべきである。
+
+想定する属性:
+
+- `kind`
+- `id` または `stable_id`
+- `role`
+- `value`
+- `children`
+
+内部実装として `anytree` などを使う可能性はあるが、downstream package にその実装詳細への依存を強制しない。
+
+### 言語非依存性
+
+Astars の AST は完全な language-neutral IR ではない。
+
+初期方針としては、Python を reference language としつつ、他言語へ拡張できる程度に node kind や role の設計を整理する。すべての言語差を消すのではなく、downstream package が共通 workflow を使えるようにすることを優先する。
+
+## SyntaxGraph
+
+`SyntaxGraph` は、source、raw syntax、CST、AST の対応関係を保持する mapping structure である。
+
+責務:
+
+- AST node から raw syntax / source span を引けるようにする
+- source offset から node を解決できるようにする
+- node に対応する source slice を取得できるようにする
+- edit primitive の対象範囲を決める基盤になる
+
+`SyntaxGraph` は Astars の source-faithful 性を支える中核概念である。
+
+### 例
+
+downstream package は、次のような問いを `SyntaxGraph` または `SourceUnit` 経由で解けるべきである。
+
+- この `FunctionDef` node は source のどの範囲に対応するか
+- この byte offset に最も近い AST node は何か
+- この source span と重なる node はどれか
+- この node を削除する場合、どの source range を edit すべきか
+
+## SourceUnit
+
+`SourceUnit` は、1つの source input を parse した結果全体を表す public handle である。
+
+つまり、source、AST、mapping、diagnostics、query helper をまとめた単位である。v0 public API では、この名前を採用する。
+
+責務:
+
+- source を保持する
+- root node を提供する
+- diagnostics を提供する
+- traversal / query API を提供する
+- node-to-source / source-to-node mapping API を提供する
+- edit primitive の入口になる
+
+想定 API:
+
+```python
+unit = astars.parse_file("example.py", lang="python")
+
+root = unit.root
+functions = unit.find(kind="FunctionDef")
+span = unit.span_of(functions[0])
+source = unit.source_of(functions[0])
+```
+
+`SourceUnit` の具体的な method set は `API_STRATEGY.ja.md` で定義する。
+
+## Diagnostics
+
+`Diagnostics` は、parse や normalization の過程で発生した問題を表す。
+
+例:
+
+- syntax error
+- unsupported syntax
+- parser warning
+- mapping failure
+- language adapter limitation
+
+Astars は、可能であれば syntax error を即 exception にするのではなく、diagnostics として保持した `SourceUnit` を返す方針を検討する。
+
+ただし、unsupported language、parser dependency missing、invalid input のような実行不能な問題は exception として扱ってよい。
+
+## Edit Primitive
+
+`Edit Primitive` は、source-aware な最小編集操作を表す。
+
+例:
+
+- node に対応する source span を削除する
+- node に対応する source span を置換する
+- node に対応する source を抽出する
+- 複数 node selection から edit plan を作る
+
+Astars core は、generic edit primitive を提供してよい。しかし、どの node を選ぶか、なぜその編集を行うかは downstream package が判断する。
+
+## Concept Boundaries
+
+Astars の概念境界は次のように整理する。
+
+### Public Concept
+
+downstream package が通常触ってよい概念:
+
+- `SourceUnit`
+- `AST`
+- AST node interface
+- `SourceSpan`
+- diagnostics
+- query / traversal / edit primitive
+
+### Extension-Level Concept
+
+言語追加や rule 実装で触る概念:
+
+- `RawSyntaxNode`
+- AST rule
+- language adapter
+- normalization hook
+
+### Internal Concept
+
+通常の downstream package が依存しない概念:
+
+- parser object
+- parser-specific node
+- internal cache
+- private mapping index
+- implementation-specific tree library
+
+## Open Questions
+
+- CST を stable public API に含めるか
+- `RawSyntaxNode` を extension-level としてどこまで文書化するか
+- AST node kind をどこまで language-neutral にするか
+- `stable_id` の保証範囲をどう定義するか
+- source span の Unicode column 表示をどう扱うか
+- edit primitive は text を返すか、edit plan を返すか、新しい `SourceUnit` を返すか

--- a/docs/DOCS_PLAN.ja.md
+++ b/docs/DOCS_PLAN.ja.md
@@ -1,0 +1,19 @@
+# Astars ドキュメント計画
+
+ステータス: draft
+
+関連戦略: [STRATEGY.ja.md](STRATEGY.ja.md)
+
+この文書は、Astars のドキュメントをどの粒度に分けるかを整理するための叩き台である。
+
+想定する文書構成は次の通り。
+
+- `STRATEGY.md` / `STRATEGY.ja.md`: 上位方針、独自性、ecosystem、trade-off
+- `API_STRATEGY.md` / `API_STRATEGY.ja.md`: public API、extension API、internal API の境界
+- `CONCEPTS.md` / `CONCEPTS.ja.md`: `RawSyntaxNode`, CST, AST, `SyntaxGraph`, source span の概念定義
+- `USE_CASES.md` / `USE_CASES.ja.md`: research / practical use cases の詳細
+- `ARCHITECTURE.md` / `ARCHITECTURE.ja.md`: module 構成、依存方向、data flow
+- `ROADMAP.md` / `ROADMAP.ja.md`: 実装 phase、milestone、release plan
+- `MIGRATION.md` / `MIGRATION.ja.md`: 旧 API から新 API への移行方針
+
+分割の基準は、読む人の関心である。戦略判断を知りたい人は `STRATEGY`、実装に入る人は `ARCHITECTURE`、downstream package を作る人は `API_STRATEGY` と `CONCEPTS` を読む、という状態を目指す。

--- a/docs/MIGRATION.ja.md
+++ b/docs/MIGRATION.ja.md
@@ -1,0 +1,479 @@
+# Astars 移行計画
+
+ステータス: draft
+
+関連文書:
+
+- [STRATEGY.ja.md](STRATEGY.ja.md)
+- [CONCEPTS.ja.md](CONCEPTS.ja.md)
+- [ARCHITECTURE.ja.md](ARCHITECTURE.ja.md)
+- [API_STRATEGY.ja.md](API_STRATEGY.ja.md)
+- [ROADMAP.ja.md](ROADMAP.ja.md)
+
+この文書は、現在の Astars repository を、軽量な program structure engine としての Astars に移行するための叩き台である。
+
+目的は、既存実装を一気に捨てることではなく、すでにある parser adapter、core syntax、CST/AST builder、source mapping の芽を、明確な module boundary と public API に整理することである。
+
+## Migration Goal
+
+移行後の Astars は、次の状態を目指す。
+
+1. `astars` を engine package として使える
+2. downstream package は `astars.parse_file` / `astars.parse_str` から始められる
+3. parser-specific object を通常の user-facing API に露出しない
+4. AST-like structure と source span の対応を engine の中核機能として扱う
+5. traversal、query、source extraction、generic edit primitive を engine operation として提供する
+6. metrics、code review、LLM evaluation、pruning policy などは downstream package に分離できる
+
+現時点では、`astars` という名前を engine の中核 package として使い、`astars-metrics`、`astars-code-review`、`astars-llm-eval` のような package が周辺に広がる前提とする。
+
+## Migration Principles
+
+移行では、次の原則を優先する。
+
+- big-bang rewrite にしない
+- public API を先に小さく固定する
+- source mapping を後付け機能にしない
+- tree-sitter などの parser 依存を adapter に閉じ込める
+- domain-specific logic を engine core に入れない
+- 既存名を残す場合は thin compatibility shim として扱う
+- module rename は、責務の整理が見えた後に行う
+- examples と README は、古い API の正当化ではなく、新しい API の利用例として更新する
+
+重要なのは、ディレクトリ名を先に完璧に揃えることではない。まず `SourceUnit`、AST node、`SourceSpan`、`SyntaxGraph` の関係を安定させ、それを public API として使える形にする。
+
+## Current State
+
+現在の repository には、目標アーキテクチャに近い部品と、まだ責務が曖昧な部品が混在している。
+
+```mermaid
+flowchart LR
+    Current["current repository\nmixed responsibilities"]
+    API["public API\nnot stable yet"]
+    Core["core syntax / CST / AST\npromising but boundary unclear"]
+    Adapter["parser adapter\npartially isolated"]
+    Usecase["usecase\nengine operation or downstream logic?"]
+    Examples["README / examples\nlegacy API"]
+
+    Current --> API
+    Current --> Core
+    Current --> Adapter
+    Current --> Usecase
+    Current --> Examples
+```
+
+主な gap は次の通り。
+
+- `astars.__init__` が安定 public API として整理されていない
+- `astars/api.py` と `astars/engine.py` の責務が未定義
+- `usecase/` が engine operation と domain-specific use case のどちらを表すのか曖昧
+- `adapter/edit/` が adapter なのか edit operation なのか曖昧
+- `core/syntax`, `core/cst`, `core/ast` は方向性が近いが、public boundary が未整理
+- README と examples が `AParser`, `APruner` などの legacy API を前提としている
+- package metadata に runtime dependency と supported language の方針が十分に反映されていない
+- tests が新しい engine surface を守る形になっていない
+
+## Target Shape
+
+移行後の概念的な依存方向は次の通り。
+
+```mermaid
+flowchart TB
+    Downstream["downstream packages\nastars-metrics / astars-code-review / astars-llm-eval"]
+
+    subgraph Engine["astars engine"]
+        Public["public API\nparse_file / parse_str / SourceUnit"]
+        Ops["operations\nquery / traversal / edit"]
+        Core["core model\nSourceText / SourceSpan / AST / SyntaxGraph"]
+        Lang["language support\nPython rules / registry"]
+        Adapter["adapters\ntree-sitter"]
+    end
+
+    Parser["external parser infrastructure"]
+
+    Downstream --> Public
+    Public --> Ops
+    Public --> Core
+    Ops --> Core
+    Core --> Lang
+    Lang --> Adapter
+    Adapter --> Parser
+```
+
+この形では、downstream package は Astars の public API に依存する。Astars core は parser object や downstream policy に依存しない。
+
+## Migration Phases
+
+### Phase 0: 移行前提を固定する
+
+最初に、移行中にぶれやすい前提を文書化する。
+
+決めること:
+
+- package/import 名は当面 `astars` を維持する
+- `astars` は engine package として扱う
+- `astars-*` は engine を使う downstream package として扱う
+- source mapping は engine の中核価値として扱う
+- pruning は engine operation ではなく downstream policy の候補として扱う
+
+成果物:
+
+- `STRATEGY.ja.md` の方針確認
+- `CONCEPTS.ja.md` の概念名確認
+- `ARCHITECTURE.ja.md` の module boundary 確認
+
+### Phase 1: Public API Surface を作る
+
+まず、downstream package が依存する入口を小さく作る。
+
+Phase 1 では、`API_STRATEGY.ja.md` の `Initial Public API` を実装対象とする。
+
+実装対象:
+
+- `astars.parse_file`
+- `astars.parse_str`
+- `astars.parse_bytes`
+- `SourceUnit`
+- `SourceSpan`
+- `Diagnostic`
+- 最小の AST node interface
+
+判断すること:
+
+- `astars/api.py` を維持するか、`astars/api/` package に分けるか
+- `AParser` を compatibility shim として残すか
+- concrete AST node class 名を public にするか、interface のみを public contract とするか
+
+この phase の完了条件:
+
+- user が tree-sitter object を直接触らずに Python source を parse できる
+- root node、diagnostics、source mapping に public handle からアクセスできる
+- README の最初の example を新 API で書ける
+- `unit.find(kind="FunctionDef")` から `unit.span_of(node)` / `unit.source_of(node)` まで通る
+
+### Phase 2: Core Model を安定させる
+
+次に、public API の裏側にある core model を整理する。
+
+実装対象:
+
+- `SourceText`
+- `SourceSpan`
+- `RawSyntaxNode`
+- CST
+- AST
+- `SyntaxGraph`
+- diagnostics
+
+整理すること:
+
+- byte offset を canonical representation として扱う
+- line/column は表示用または diagnostics 用として扱う
+- parser-specific object を core model に保持しない
+- AST node から source span を引けることを invariant に近い扱いにする
+- source span から source slice を取れることを public workflow に含める
+
+この phase の完了条件:
+
+- AST node と source range の対応が test で守られている
+- `unit.source_of(node)` または同等の API が成立する
+- parse error や unsupported syntax を diagnostics として扱う方針が見えている
+
+### Phase 3: Parser Adapter と Language Support を分ける
+
+tree-sitter との接続と、言語固有の AST rule を分離する。
+
+実装対象:
+
+- parser adapter contract
+- tree-sitter adapter
+- language registry
+- Python rule set
+
+整理すること:
+
+- adapter は parser を呼び出し、parser node を `RawSyntaxNode` に変換する
+- language support は `RawSyntaxNode` から CST/AST を構築する rule を持つ
+- core model は adapter の実装詳細を知らない
+- Python を reference language として扱う
+
+この phase の完了条件:
+
+- tree-sitter dependency の不足をわかりやすい exception または diagnostic にできる
+- Python parse path が adapter 経由で安定して動く
+- second language を追加する時の拡張点が見える
+
+### Phase 4: Engine Operations を定義する
+
+generic な操作を `operations/` に集める。
+
+実装対象:
+
+- traversal
+- query
+- source lookup
+- source extraction
+- edit plan
+- delete / replace / extract などの edit primitive
+
+入れないもの:
+
+- metrics definition
+- code review policy
+- pruning strategy
+- LLM prompt policy
+- CI integration
+- report generation
+
+この phase の完了条件:
+
+- downstream package が `SourceUnit` から node を探せる
+- node から source span と source slice を取得できる
+- node selection を受け取り、source-aware な edit plan を作れる
+- 何を対象にするかという判断は downstream に残っている
+
+### Phase 5: Legacy API と Examples を整理する
+
+public API が固まったら、既存 API と example を整理する。
+
+対象:
+
+- `AParser`
+- `APruner`
+- `ATraverser`
+- README
+- `examples/`
+- `astars/cli/demo.py`
+
+判断すること:
+
+- `AParser` をどの期間 compatibility shim として残すか
+- `APruner` を engine から外すか、downstream example に移すか
+- `ATraverser` 相当を `operations.traversal` に移すか
+- 古い example を削除するか、新 API に書き換えるか
+
+この phase の完了条件:
+
+- README が新しい engine API を説明している
+- examples が source mapping を含む Astars の価値を示している
+- legacy API を使う必要がある場合、deprecated であることが明確になっている
+
+### Phase 6: Packaging と Release Path を整える
+
+engine として利用できる package にする。
+
+実装対象:
+
+- `pyproject.toml`
+- package discovery
+- runtime dependencies
+- optional dependencies
+- supported Python versions
+- versioning
+- minimal install test
+
+判断すること:
+
+- `tree-sitter` / `tree-sitter-python` を必須 dependency にするか optional extra にするか
+- `anytree` を public implementation detail として露出しないか
+- `astars[python]` のような extra を用意するか
+- PyPI package と GitHub repository の naming をどう扱うか
+
+この phase の完了条件:
+
+- clean environment で install できる
+- install 後に `import astars` と Python parse smoke test が通る
+- dependency 不足時の error が user にとって理解しやすい
+
+### Phase 7: Tests で移行を固定する
+
+最後に、移行で壊してはいけない engine behavior を test で固定する。
+
+優先する test:
+
+- parse smoke test
+- AST node interface test
+- source span mapping test
+- source slice test
+- query test
+- traversal test
+- edit primitive test
+- diagnostics test
+- packaging/import smoke test
+
+この phase の完了条件:
+
+- 新しい public API の最小 workflow が CI で守られている
+- source mapping の regressions を検出できる
+- legacy API の shim を残す場合、その compatibility 範囲が test で明確になっている
+
+## File Mapping Draft
+
+現行の主な module と、移行後の候補は次の通り。
+
+| Current | Target | Note |
+| --- | --- | --- |
+| `astars/__init__.py` | `astars/__init__.py` | stable public API の再 export に限定する |
+| `astars/api.py` | `astars/api.py` または `astars/api/parse.py` | `parse_file` / `parse_str` / `SourceUnit` の入口 |
+| `astars/engine.py` | 削除または `astars/api` に統合 | 責務が明確になるまで public surface にしない |
+| `astars/adapter/parse/base.py` | `astars/adapters/parse/base.py` | parser adapter contract |
+| `astars/adapter/parse/treesitter.py` | `astars/adapters/parse/tree_sitter.py` | tree-sitter 固有処理 |
+| `astars/adapter/edit/*` | `astars/operations/edit/*` | generic edit primitive なら operation に移す |
+| `astars/core/text/text.py` | `astars/core/source/text.py` | `SourceText` として整理する |
+| `astars/core/syntax/raw.py` | `astars/core/syntax/raw.py` | `RawSyntaxNode` として維持 |
+| `astars/core/syntax/mapping.py` | `astars/core/mapping/syntax_graph.py` | `SyntaxGraph` として明確化 |
+| `astars/core/syntax/query.py` | `astars/operations/query/*` | generic query operation に移す |
+| `astars/core/cst/*` | `astars/core/cst/*` | public か extension-level かを決める |
+| `astars/core/ast/*` | `astars/core/ast/*` | AST node interface を安定化する |
+| `astars/usecase/analyse/walk.py` | `astars/operations/traversal/*` | engine generic traversal として扱う |
+| `astars/usecase/transform/prune.py` | downstream package または example | pruning policy は engine core から外す |
+| `astars/utils/source_pos.py` | `astars/core/source/*` | source position 変換として統合する |
+| `astars/cli/demo.py` | `examples/` または thin CLI | engine API の smoke/demo にする |
+| `README.md` | `README.md` | legacy API ではなく新 API に更新する |
+
+この表は機械的な rename 指示ではない。先に責務と public API を固め、移動は test を追加しながら段階的に行う。
+
+## Suggested Migration Order
+
+実装時は、次の順序で進めるとリスクが小さい。
+
+```mermaid
+flowchart TD
+    S0["0. Strategy / concepts / architecture"]
+    S1["1. Public parse API"]
+    S2["2. SourceText / SourceSpan"]
+    S3["3. RawSyntaxNode and mapping"]
+    S4["4. SourceUnit"]
+    S5["5. Query / traversal"]
+    S6["6. Edit primitives"]
+    S7["7. Legacy cleanup"]
+    S8["8. Packaging / docs / tests"]
+
+    S0 --> S1
+    S1 --> S2
+    S2 --> S3
+    S3 --> S4
+    S4 --> S5
+    S5 --> S6
+    S6 --> S7
+    S7 --> S8
+```
+
+各 step では、最初に small public example を1つ作り、その example を動かすために必要な internal を整理する。
+
+## Compatibility Policy Draft
+
+古い API を残すかどうかは、移行コストと将来の API clarity のバランスで決める。
+
+### `AParser`
+
+`AParser` は、短期的には `astars.parse_str` / `astars.parse_file` を呼ぶ thin wrapper として残す余地がある。
+
+ただし、新しい README や examples では `AParser` を主役にしない。将来の public API は function-based parse entry と `SourceUnit` を中心にする。
+
+### `APruner`
+
+`APruner` は、Astars engine の中核からは外す候補である。
+
+理由は、pruning が「source-aware edit primitive」ではなく「何をどの順序で削るか」という domain policy を含むためである。残す場合は、`astars-pruning` のような downstream package、または example として扱う。
+
+### `ATraverser`
+
+`ATraverser` 相当の機能は、generic traversal primitive として `operations/traversal` に整理する候補である。
+
+ただし、class 名を public API として残すかは別問題である。初期 public API では、`unit.walk()` や `astars.walk(node)` のような小さい helper の方が扱いやすい可能性がある。
+
+## Do Not Migrate Into Core
+
+次の機能は、便利でも engine core に入れない方針を維持する。
+
+- metric の定義
+- smell / antipattern の判定
+- code review comment の文章生成
+- LLM prompt の組み立て
+- pruning の探索戦略
+- report / visualization
+- GitHub / CI integration
+- project-specific rule
+
+これらは Astars の上に作る downstream package の責務である。
+
+## Minimum End-to-End Example
+
+移行の目標を確認するため、最初に次の workflow を通す。
+
+```python
+import astars
+
+unit = astars.parse_str(
+    "def hello(name):\n    return f'hello {name}'\n",
+    lang="python",
+)
+
+functions = unit.find(kind="FunctionDef")
+span = unit.span_of(functions[0])
+source = unit.source_of(functions[0])
+```
+
+この例で確認したいこと:
+
+- `import astars` から始められる
+- parser-specific object が user に見えない
+- AST-like node を query できる
+- node から source span に戻れる
+- node から source slice を取得できる
+
+edit primitive まで含める場合は、次のような workflow を目標にする。
+
+```python
+plan = unit.edit.delete(functions[0])
+new_source = plan.apply()
+```
+
+ここで Astars が判断するのは、選ばれた node を source にどう反映するかである。どの node を削除するべきかは downstream package が判断する。
+
+## Open Decisions
+
+現時点で未決定の項目は次の通り。
+
+- `astars/api.py` を単一 file にするか、`astars/api/` package にするか
+- CST を stable public API とするか
+- `RawSyntaxNode` を extension-level API として文書化するか
+- `tree-sitter-python` を必須依存にするか optional extra にするか
+- `AParser` を残す場合の deprecation policy
+- `APruner` を downstream package 化するか、example に落とすか
+- `operations/edit` と lower-level text editing backend の責務をどう分けるか
+- repository 名と package 名を将来分ける必要があるか
+
+## Near-Term Checklist
+
+短期的には、次の順序で進める。
+
+- [x] `astars` の public API として最低限公開する名前を決める
+- [ ] `SourceUnit` object を定義する
+- [ ] `SourceText` / `SourceSpan` を source mapping の基準として整理する
+- [ ] tree-sitter parse result を `RawSyntaxNode` に変換する path を安定させる
+- [ ] AST node から source span を取得する test を追加する
+- [ ] README の最初の example を新 API に置き換える
+- [ ] legacy API の扱いを決める
+- [ ] pruning を engine core に残すか downstream に出すか判断する
+- [ ] clean environment install と parse smoke test を通す
+
+## Migration Success Signals
+
+移行がうまく進んでいる状態は、次のように判断できる。
+
+- downstream package が `astars.adapter` を直接 import しなくなる
+- parser object を知らなくても source-aware analysis が書ける
+- AST node から source span に戻る処理が自然に書ける
+- edit primitive が domain policy と分離されている
+- README の最初の example が engine の価値を示している
+- 新しい use case を追加しても core に policy が増えない
+
+逆に、次の状態になった場合は移行方針を見直す。
+
+- public API が internal object の寄せ集めになっている
+- `usecase/` に engine operation と downstream policy が混在し続ける
+- source mapping が optional helper 扱いになっている
+- core に metrics、review、pruning、LLM の判断が入り始める
+- parser-specific API を downstream package が直接使い続ける

--- a/docs/ROADMAP.ja.md
+++ b/docs/ROADMAP.ja.md
@@ -1,0 +1,118 @@
+# Astars ロードマップ
+
+ステータス: draft
+
+関連戦略: [STRATEGY.ja.md](STRATEGY.ja.md)
+
+この文書は、Astars の導入ストーリーと近い実装戦略を整理する。
+
+## 導入ストーリー
+
+Astars の導入は、いきなり大きな ecosystem を作るのではなく、小さな engine workflow から始める。
+
+### Step 1: Parse And Inspect
+
+まず、Python source を parse し、AST-like structure を inspect できる状態にする。
+
+この段階で重要なのは、downstream user が tree-sitter object を直接触らなくても、node kind、children、source span を扱えることである。
+
+### Step 2: Query And Source Mapping
+
+次に、function、class、import、statement などを query し、それらを source span に戻せるようにする。
+
+この段階で、metrics、review、LLM context extraction などの下流ユースケースが prototype として成立し始める。
+
+### Step 3: Generic Edit Primitives
+
+node に対応する source span の削除、置換、抽出など、generic な edit primitive を提供する。
+
+この段階で重要なのは、Astars core が「何を編集すべきか」は決めず、「選ばれた node を source にどう反映するか」を支えることである。
+
+### Step 4: Downstream Package 化
+
+特定の分析目的が見えてきたら、`astars-metrics`, `astars-code-review`, `astars-pruning` のような downstream package に分ける。
+
+core に入れるべきか迷った機能は、「他のユースケースでも使える primitive か」「特定の分析判断か」で分ける。
+
+### Step 5: Language Expansion
+
+Python reference path が安定したら、second language を使って adapter contract と AST rule contract を検証する。
+
+この段階でも、downstream package が parser-specific API を直接学ばなくてよい状態を保つ。
+
+
+## 近い戦略
+
+### Phase 1: Engine Surface を安定させる
+
+- public API を定義する
+- `AParser` のような legacy name を compatibility shim として残すか判断する
+- runtime dependency が正しく install されるように package metadata を整える
+- README と examples を新 API に合わせる
+- clean environment で basic parse/query workflow が動くようにする
+- `astars-engine` への repository/package migration plan を決める
+
+### Phase 2: Core Model を安定させる
+
+- `RawSyntaxNode`, CST, AST, `SyntaxGraph` の役割を明確にする
+- CST を public API とするか、主に internal/debugging support とするか判断する
+- 複数の child selector が同じ attribute を対象にする場合の rule semantics を直す
+- source span mapping と AST construction の test を追加する
+
+### Phase 3: Engine Operations を定義する
+
+- traversal primitive を追加する
+- query primitive を追加する
+- source extraction primitive を追加する
+- generic edit/transform primitive を追加する
+- domain-specific analysis strategy は core に入れない
+
+### Phase 4: Ecosystem に備える
+
+- `astars` と `astars-*` package の境界を文書化する
+- downstream analysis module 向けの extension point を定義する
+- 最小の downstream example package または example project を作る
+- application-specific dependency を engine に追加しない
+
+### Phase 5: Language Expansion に備える
+
+- language adapter contract を文書化する
+- AST rule contract を文書化する
+- Java などを second-language validation target として扱う
+- Python reference path が安定する前に広い multi-language support を約束しない
+
+
+## 成功 / 失敗シグナル
+
+Astars が正しい方向に進んでいるかは、実装量ではなく、downstream package が core engine をどれだけ自然に再利用できるかで判断する。
+
+### Success Signals
+
+Astars が正しい方向に進んでいる状態とは、downstream analysis module が次を実現できる状態である。
+
+1. Astars を library として import できる
+2. source file を parse できる
+3. 安定した AST-like structure を inspect できる
+4. analysis result を source span に戻せる
+5. generic source-aware operation を実行できる
+6. parser 固有の node API に直接依存しなくてよい
+7. unrelated な `astars-*` package から独立して使える
+
+追加の成功シグナル:
+
+- downstream package が parser adapter を直接 import しなくなる
+- source span 付き finding を簡単に出せる
+- 複数の downstream tool が同じ parsed structure を共有できる
+- 新しい use case が core 変更なしに実装できる
+- core に重い application-specific dependency が増えない
+
+### Non-Success Signals
+
+Astars は、次の状態になり始めたらスコープから外れつつある。
+
+- core に metrics definition、review policy、pruning policy が入り始める
+- downstream package が private module や parser-specific object に依存し始める
+- source mapping が後付けの optional feature になっている
+- public API が内部実装をそのまま露出しすぎている
+- core が visualization、reporting、CI workflow まで抱え始める
+- `astars` が `astars-*` package をまとめて install する umbrella package になり始める

--- a/docs/STRATEGY.ja.md
+++ b/docs/STRATEGY.ja.md
@@ -1,0 +1,431 @@
+# Astars 戦略
+
+ステータス: draft
+
+English version: [STRATEGY.md](STRATEGY.md)（日本語版の分割内容は未同期）
+
+この文書は、Astars の上位戦略を揃えるための叩き台である。パッケージ構成、クラス名、実装詳細よりも上のレイヤーで、Astars が何を目指し、何を目指さないかを定義する。
+
+詳細なユースケース、実装ロードマップ、ドキュメント構成は次の文書に分ける。
+
+- [USE_CASES.ja.md](USE_CASES.ja.md): research / practical use cases
+- [ROADMAP.ja.md](ROADMAP.ja.md): adoption story と近い実装戦略
+- [DOCS_PLAN.ja.md](DOCS_PLAN.ja.md): ドキュメント分割計画
+
+## ビジョン
+
+Astars は、プログラム分析のための構造エンジンである。
+
+Astars は、分析結果が何を意味するかを判断しない。また、その結果に基づいて何を行うべきかも判断しない。代わりに、外部の分析モジュールがコードを安定して解析・検索・比較・変形できるように、ソース位置と対応づいたプログラム構造を提供する。
+
+短く言えば、Astars は次のためのエンジンである。
+
+> parser 固有の構文木を、分析に使いやすいプログラム構造へ変換する。
+
+## 想定利用者
+
+Astars は、単体で完結する分析アプリケーションではなく、分析ツールを作る人のための engine である。主な利用者は次の層を想定する。
+
+### Downstream Package Author
+
+`astars-metrics`, `astars-code-review`, `astars-pruning`, `astars-llm-eval` など、Astars を取り込んで分析・応用 package を作る人。
+
+この層にとって重要なのは、parser の詳細に依存せず、安定した parse/query/source-mapping API に依存できることである。
+
+### Software Engineering Researcher
+
+repository mining、program reduction、code model evaluation、変換実験などを行う研究者。
+
+この層にとって重要なのは、実験ごとに parser glue を作り直さず、source span と node の対応を保持したまま構造データを扱えることである。
+
+### Practical Engineering Team
+
+社内の code review 補助、migration、architecture rule check、LLM coding assistant、test impact analysis などを作る開発チーム。
+
+この層にとって重要なのは、組織固有の policy や workflow を downstream 側に置きつつ、共通のコード構造 engine を再利用できることである。
+
+### Language Extension Contributor
+
+新しい言語 adapter や AST rule を追加する contributor。
+
+この層にとって重要なのは、parser 固有の処理を adapter に閉じ込め、Astars の core concept へどう写像するかを明確にできることである。
+
+## エコシステム戦略
+
+Astars は、エコシステム全体の中核エンジンである。
+
+`astars` という名前は、関連プロジェクトをすべて取り込む umbrella package として空けておくのではなく、軽量な中核エンジンの名前として使う。umbrella package を作ると、依存関係、バージョン管理、責務境界の管理が重くなりやすい。
+
+そのため、方針は次の通りとする。
+
+- `astars` は軽量な core engine である。
+- `astars-*` は、Astars を使う分析・応用パッケージである。
+- downstream package は `astars` に依存する。
+- `astars` core は downstream package に依存しない。
+
+推奨する命名は次の通り。
+
+- Repository: `astars-engine`
+- PyPI distribution: `astars`
+- Python import namespace: `astars`
+- Downstream repositories/distributions: `astars-metrics`, `astars-code-review`, `astars-pruning` など
+
+これにより、利用者は中核エンジンを自然に `import astars` でき、同時に `astars-*` という名前で周辺パッケージを展開できる。
+
+## モチベーション
+
+プログラム分析では、よく同じ問題が繰り返し発生する。
+
+- parser の API が言語や実装ごとに異なる。
+- 具体構文木には parser 固有の細かな情報が多く含まれる。
+- 分析コードでは、木のノードと元ソースコードを行き来する必要がある。
+- コード変形では、抽象的な意味だけでなく正確な source span が必要になる。
+- 研究プロトタイプでは、parse、traverse、tree mapping の層を何度も作り直しがちである。
+
+Astars は、この共通基盤を提供するために存在する。各分析ツールが parser setup、tree normalization、source span mapping、traversal primitive を毎回自前で持たなくてもよい状態を目指す。
+
+## 既存ツールとの差分
+
+Astars は、ソースコードを parse、分析、変形する初めてのツールではない。したがって、Astars の価値は、既存ツールと何が違うのかを明確にして初めて安定する。
+
+### Parser Infrastructure
+
+例: [tree-sitter](https://tree-sitter.github.io/tree-sitter/)
+
+parser infrastructure は、source code を syntax tree に変換することに優れている。特に tree-sitter は、多数の言語に対して高速で堅牢な incremental concrete syntax tree を提供する。
+
+Astars は parser infrastructure と競合するのではなく、その上に乗る。
+
+違いは次の通り。
+
+- tree-sitter は parsing layer である。
+- Astars は parsing の上にある analysis engine layer である。
+
+Astars は parser 固有の API を adapter に閉じ込め、parser output を Astars-owned structure に normalize し、downstream analysis package のために source mapping を保持する。
+
+### 言語固有の AST/CST Framework
+
+例: Python `ast`, [LibCST](https://libcst.readthedocs.io/), [Roslyn](https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/compiler-api-model), [Clang LibTooling](https://clang.llvm.org/docs/LibTooling.html), [Babel parser/traverse](https://babel.dev/docs/babel-traverse)
+
+これらのツールは、それぞれの言語や platform の中で強い。特定言語に対して深い syntax、semantic、transformation capability を提供することが多い。
+
+Astars はこれらを置き換えようとしない。
+
+違いは次の通り。
+
+- 言語固有 framework は、1 つの言語 ecosystem に最適化されている。
+- Astars は、分析モジュール群が共通して使える engine shape に最適化する。
+
+Astars は Python から始めてよい。ただし core engine と language-specific adapter/rule を分離し、downstream analysis package が同じ parse/query/source-mapping workflow を再利用できる状態を目指す。
+
+### Static Analysis Platform / Query Engine
+
+例: [CodeQL](https://codeql.github.com/docs/codeql-overview/about-codeql/), [Semgrep](https://semgrep.dev/docs/semgrep-code/overview), [Joern](https://docs.joern.io/)
+
+これらのツールは、多くの場合、完成された分析 workflow を提供する。query language、security rule、data-flow / taint analysis、reporting、CI integration、vulnerability discovery workflow などを含むことがある。
+
+Astars は security scanner や完成された analysis product として競争しない。
+
+違いは次の通り。
+
+- static analysis platform は、分析の表現方法や finding の意味づけまで提供することが多い。
+- Astars は、そのような分析を構築するための structural substrate を提供する。
+
+Joern は code property graph に基づく query analysis platform であり、概念的には Astars に近い部分がある。ただし Astars はより軽量な位置に留まる。graph database を必須にせず、built-in vulnerability query language を持たず、security workflow を標準搭載しない。Astars の中心は、composable な Python package のための source-faithful program structure である。
+
+### Refactoring / Code Transformation Framework
+
+例: [OpenRewrite](https://docs.openrewrite.org/), LibCST codemods
+
+transformation framework は、recipe、codemod、migration rule などを通じて、安全に code を変更することに焦点を置く。
+
+Astars は generic な source-aware edit primitive を提供してよいが、domain-specific な transformation strategy は所有しない。
+
+違いは次の通り。
+
+- refactoring framework は、変形の判断や recipe を提供する。
+- Astars は、downstream transformation package が利用できる source mapping と primitive operation を提供する。
+
+たとえば、「選択された node に対応する source span を削除する」は Astars primitive でよい。一方で、「pruning 実験のためにどの statement を削除するか」は `astars-pruning` などの downstream package に属する。
+
+### Source Markup / Exchange Format
+
+例: [srcML](https://www.srcml.org/about.html)
+
+source markup tool は、source code を XML などの exchange format として表現し、その表現を通じて source structure にアクセスできるようにする。
+
+Astars は、それとは異なり、library-first な engine として設計する。小さな Python API、analysis-ready な node interface、明示的な source span mapping を中心に置く。
+
+違いは次の通り。
+
+- source markup tool は、portable な representation format を重視する。
+- Astars は、analysis package が組み合わせて使える runtime API を重視する。
+
+### Astars が埋めるべき隙間
+
+Astars の価値は、ユーザーが次を求めるときにある。
+
+- full static analysis platform ではなく lightweight engine が欲しい。
+- parser node API に直接依存せず、parser isolation が欲しい。
+- abstract syntax だけでなく、元 source に戻れる source-faithful mapping が欲しい。
+- downstream analysis package のための reusable primitive が欲しい。
+- research prototype と packaged analysis tool の両方を支えられる Python library surface が欲しい。
+- core を umbrella package にせず、`astars-*` ecosystem の土台が欲しい。
+
+この隙間を埋めることが、Astars の戦略的な位置づけである。
+
+### Core Differentiator
+
+Astars のオリジナリティは、「syntax tree を通じて code を編集できる唯一のツールである」という点には置かない。既存にも、source code を parse、rewrite、regenerate できるツールは複数存在する。
+
+Astars のオリジナリティは、次の組み合わせにある。
+
+> Astars は、source-faithful で編集可能な program structure を、downstream analysis package のための軽量で analysis-neutral な engine として提供する。
+
+つまり Astars は、source に戻れる構造編集を、完成された refactoring product、scanner、codemod framework、言語固有 toolkit としてではなく、再利用可能な engine primitive として提供する。
+
+重要な違いは次の通り。
+
+- 既存ツールの多くは、parsing、analysis intent、transformation recipe、reporting、CLI workflow、言語固有の仮定をまとめて提供する。
+- Astars は、parser-isolated な structure、source mapping、traversal、query、edit primitive を公開し、他の package がそれらを組み合わせられるようにする。
+
+言い換えると、Astars は AST editing、source generation、tree querying のような単一機能だけで独自性を主張しない。価値は、それらの能力を `astars-*` ecosystem のための小さな engine surface としてまとめる点にある。
+
+## Design Bets
+
+Astars は、いくつかの設計上の賭けに基づいて作る。これらは、実装や API に迷ったときの判断基準になる。
+
+### Source Mapping は Core Value である
+
+Astars の価値は、単に tree を作ることではなく、分析対象の node から元 source に戻れることにある。source span、source slice、edit primitive は後付けの補助機能ではなく、core concept として扱う。
+
+### Parser は交換可能であるべき
+
+初期実装では tree-sitter を使うが、Astars の public workflow が tree-sitter object に直接依存しないようにする。parser 固有の API は adapter に閉じ込め、downstream package は Astars-owned structure に依存する。
+
+### AST は Analysis-Friendly、CST は Source-Faithful として役割を分ける
+
+分析しやすい抽象構造と、source に忠実な構文情報は役割が違う。Astars は AST-like structure を分析の主対象にしつつ、source span や raw syntax との mapping を通じて source-faithful な操作を可能にする。
+
+### Core は軽く保つ
+
+`astars` core は、downstream package が安心して依存できる軽量 engine として保つ。metrics、review policy、pruning strategy、visualization、reporting などは core に入れず、`astars-*` package に分離する。
+
+### Public API は小さく保つ
+
+Astars は、広い内部構造をそのまま public API として公開しない。downstream package が依存する surface を小さく保つことで、engine の進化と ecosystem の安定性を両立させる。
+
+### Python を Reference Path にする
+
+最初は Python を reference language として、parse、AST construction、source mapping、query、edit primitive の一連の流れを安定させる。その上で、他言語対応を architecture の検証対象として広げる。
+
+## Trade-offs
+
+Astars は、すべての方向に広げるのではなく、engine としての価値を守るためにいくつかの trade-off を受け入れる。
+
+### Full Semantic Analysis は持たない
+
+型解決、data-flow、taint analysis、symbol resolution などは重要だが、初期 core の責務にはしない。必要であれば downstream package や外部 tool と組み合わせる。
+
+### Formatting Preservation の完全性を最初から約束しない
+
+Astars は source-faithful な mapping と edit primitive を重視するが、初期段階からすべての formatting、comment、空白、括弧の完全な保持を保証するわけではない。lossless transformation をどこまで保証するかは、API と実装が安定してから段階的に定義する。
+
+### 多言語対応より Reference Path の安定を優先する
+
+Astars は language-extensible であるべきだが、最初から広い language coverage を約束しない。Python で engine の形を固め、それから second language で設計を検証する。
+
+### 汎用性より小さな Public API を優先する
+
+内部的には多くの情報を持っていても、public API として安定させる範囲は絞る。必要な情報を全部露出するより、downstream package が長く依存できる小さな contract を優先する。
+
+### Product ではなく Engine に留まる
+
+Astars は CLI scanner、code review product、metrics dashboard、refactoring recipe collection にならない。そうした機能は downstream package として作る。
+
+## 位置づけ
+
+Astars は engine であり、end-user 向けの分析プロダクトではない。
+
+Astars は、他のツールが依存できる構造的な土台を提供する。メトリクス計算、コード smell 検出、レポート生成、pruning、LLM 出力評価、可視化、レビュー支援などは、Astars の上に構築される downstream package の責務である。
+
+想定される downstream package の例:
+
+- `astars-metrics`: complexity、node count、source statistics など
+- `astars-pruning`: 研究用途の pruning strategy
+- `astars-code-review`: code review 向けの分析 workflow
+- `astars-llm-eval`: code model evaluation dataset 向け utility
+- `astars-visualizer`: graph や source mapping の可視化
+
+これらは Astars core に組み込むのではなく、Astars を import して使う別パッケージとして設計する。
+
+概念的には、Astars は ecosystem の中心に位置する。
+
+```mermaid
+flowchart TB
+    subgraph Downstream["Downstream astars-* packages"]
+        Metrics["astars-metrics\nmetrics / statistics"]
+        Review["astars-code-review\nreview workflows"]
+        Pruning["astars-pruning\nprogram reduction"]
+        Eval["astars-llm-eval\nmodel evaluation"]
+        Viz["astars-visualizer\nvisual exploration"]
+    end
+
+    subgraph Engine["astars core engine"]
+        API["Public API"]
+        Ops["Query / Traverse / Edit primitives"]
+        Model["AST-like structures\nSource spans\nSyntaxGraph"]
+        Adapter["Parser adapters\n(tree-sitter, etc.)"]
+    end
+
+    Parsers["Parser infrastructure"]
+    Source["Source code"]
+
+    Metrics --> API
+    Review --> API
+    Pruning --> API
+    Eval --> API
+    Viz --> API
+
+    API --> Ops
+    Ops --> Model
+    Model --> Adapter
+    Adapter --> Parsers
+    Parsers --> Source
+```
+
+依存方向は `astars` core に向かう。downstream package は engine に依存するが、engine は downstream analysis package には依存しない。
+
+## Core の責務
+
+Astars core は、少数の engine responsibility に集中する。
+
+### Parse
+
+ソースコードを読み、parser 実装を呼び出す。初期実装では tree-sitter を想定する。
+
+parser integration は system boundary に置く。parser 固有の API は、engine の外側に漏らさず adapter 層に閉じ込める。
+
+### Normalize
+
+parser 固有の構造を、Astars が所有する表現へ変換する。
+
+normalization の目的は、すべての言語差を消すことではない。目的は、raw parser node よりも分析しやすい、安定した表現を提供することである。
+
+### Map
+
+次の対応関係を信頼できる形で保持する。
+
+- source bytes/text
+- parser-origin nodes
+- Astars syntax nodes
+- AST nodes
+- source spans
+
+source mapping は Astars の中核である。分析結果は、可能な限り元ソースへ戻れるべきである。
+
+### Query And Traverse
+
+ノードを検索・走査・解決するための再利用可能な primitive を提供する。
+
+例:
+
+- AST を安定した順序で traverse する
+- kind によって node を検索する
+- source offset から node を解決する
+- node の source span を収集する
+- mapped node から source slice を取り出す
+
+### Primitive Transform
+
+汎用的で source-aware な変形 primitive のみを提供する。
+
+例:
+
+- mapped source span を削除する
+- mapped source span を置換する
+- node に対応する source を抽出する
+- node selection から edit plan を作る
+
+domain-specific な strategy は Astars core の外に置く。たとえば、「pruning 実験のために statement を reverse postorder で削除する」は downstream module の strategy であり、「この node に対応する source span を削除する」は engine primitive である。
+
+## 境界
+
+Astars は、分析結果の解釈を所有しない。
+
+Astars は、ある node が `FunctionDef` であること、source span を持つこと、children を持つことを提供してよい。しかし、その関数が複雑すぎるか、レビューコメントを作るべきか、データセットから削除すべきかは判断しない。
+
+それらの判断は、外部の分析モジュールに属する。
+
+## Core Principles
+
+### Source-Faithful
+
+Astars は、常に元ソースへ戻る経路を保持する。source span と source slice は、単なる debug convenience ではなく first-class concern である。
+
+### Parser-Isolated
+
+parser 固有の API は adapter に閉じ込める。通常の workflow では、engine user が tree-sitter node object に直接依存する必要がない状態を目指す。
+
+### Analysis-Neutral
+
+Astars は構造と primitive を提供するが、domain-specific な判断は行わない。特定の分析目的を core model に埋め込まず、多様な分析目的を支えられるようにする。
+
+### Lightweight Core
+
+Astars は、他の package が安心して依存できる軽量な core であるべきである。重い分析 workflow、可視化、reporting、研究固有の strategy は engine の外に置く。
+
+### Language-Extensible
+
+Astars は、他言語を追加できる設計にする。Python を reference language としつつ、architecture は他言語へ拡張可能な状態を保つ。
+
+### Composable
+
+Astars は library として import しやすいべきである。public API は小さく、安定し、downstream package が使いやすい形にする。
+
+### Minimal But Reliable
+
+Astars は、広く浅い分析機能を増やすよりも、少数の信頼できる primitive を提供することを優先する。
+
+## 初期スコープ
+
+最初の stable version は、Python を reference language として進める。
+
+これは Astars を長期的に Python-only にするという意味ではない。Python を使って、engine design、public API、tests、source mapping model を検証するという意味である。
+
+初期 stable scope:
+
+- Python source を string と file から parse する
+- Astars-owned syntax/AST structure を構築する
+- source-to-node と node-to-source の mapping を提供する
+- AST node を traverse/query する
+- source span extraction を提供する
+- downstream tool 向けの小さな public API を定義する
+- 言語追加の方法を文書化する
+
+## Non-Goals
+
+Astars core は次のものではない。
+
+- full compiler frontend
+- complete semantic analyzer
+- IDE または LSP implementation
+- code quality product
+- review automation product
+- metrics package
+- visualization application
+- research-specific pruning framework
+- すべての `astars-*` project を install する umbrella package
+
+これらは Astars の上に構築してよいが、core engine の責務には含めない。
+
+## Open Questions
+
+- primary parse API は `ParseResult`, `AST`, あるいは higher-level engine object のどれを返すべきか
+- `CST` は public API に含めるべきか、それとも主に AST plus source mapping を使わせるべきか
+- `AParser`, `APruner`, `ATraverser` のような legacy API は削除、deprecated、thin wrapper として再導入のどれにすべきか
+- 現在の `usecase/` package は、`operations/` や `primitives/` のような engine-oriented な名前に変えるべきか
+- AST node kind はどの程度 language-neutral にするべきか
+- Python reference language としての最小 stable rule set は何か
+- stable ID について、edit や parse をまたいでどこまで保証するべきか
+- 既存 repository を `astars-engine` に rename するべきか、新 repository を作って移植するべきか

--- a/docs/STRATEGY.ja.md
+++ b/docs/STRATEGY.ja.md
@@ -421,7 +421,7 @@ Astars core は次のものではない。
 
 ## Open Questions
 
-- primary parse API は `ParseResult`, `AST`, あるいは higher-level engine object のどれを返すべきか
+- `SourceUnit` の public method set をどこまで v0 で固定するべきか
 - `CST` は public API に含めるべきか、それとも主に AST plus source mapping を使わせるべきか
 - `AParser`, `APruner`, `ATraverser` のような legacy API は削除、deprecated、thin wrapper として再導入のどれにすべきか
 - 現在の `usecase/` package は、`operations/` や `primitives/` のような engine-oriented な名前に変えるべきか

--- a/docs/USE_CASES.ja.md
+++ b/docs/USE_CASES.ja.md
@@ -1,0 +1,183 @@
+# Astars ユースケース
+
+ステータス: draft
+
+関連戦略: [STRATEGY.ja.md](STRATEGY.ja.md)
+
+この文書は、Astars の価値を research use cases と practical engineering use cases に分けて整理する。
+
+Astars の戦略的な価値は、ユースケースごとに見るとより明確になる。ここでは大きく Research Use Cases と Practical Engineering Use Cases に分ける。
+
+## Research Use Cases
+
+研究用途では、柔軟な program structure、正確な source mapping、そして experiment-specific な analysis logic を engine の外で定義できる自由度が重要になる。
+
+### Research Pruning / Program Reduction
+
+Downstream package: `astars-pruning`
+
+研究 workflow では、tree node と source text の対応を保ったまま、program の一部を削除、置換、最小化したいことがある。
+
+Astars がある場合、pruning package は次を行える。
+
+- pruning strategy を core の外で選べる
+- generic source-aware edit primitive を使える
+- 各 edit を選択された node に追跡できる
+- 同じ source mapping model を使って reduced program を比較できる
+
+Astars は pruning policy を所有しない。node-to-source edit substrate を提供する。
+
+### LLM / Code Model Evaluation
+
+Downstream package: `astars-llm-eval`
+
+evaluation dataset では、structural slicing、prompt construction、answer checking、source-region selection などが必要になることがある。
+
+Astars がある場合、evaluation package は次を行える。
+
+- function、class、block、expression を一貫して抽出できる
+- dataset provenance のために source span を保持できる
+- parser glue を再実装せずに structural variant を作れる
+- generated code を source-mapped structure と比較できる
+
+Astars は model score や benchmark を定義しない。それらの workflow に信頼できる program structure を提供する。
+
+### Repository Mining / Software Engineering Research
+
+Downstream package: research scripts または `astars-research-*` packages
+
+ソフトウェア工学研究では、多数の repository を処理し、比較可能な program structure を抽出し、source file への link を保持したいことが多い。
+
+Astars がある場合、research workflow は次を行える。
+
+- 共通の engine surface を通じて repository を parse できる
+- function、class、import、statement を一貫して抽出できる
+- 再現性のために source span を記録できる
+- experiment ごとに parser glue を作り直さなくてよい
+
+Astars は research question を定義しない。structural data collection を信頼しやすくする。
+
+### Language Support Experiments
+
+Downstream または extension package: language adapter package / experimental language support
+
+言語を追加する際の中心課題は、各 downstream package が新しい parser API を学ぶことではなく、その言語を Astars の engine concepts にどう対応させるかである。
+
+Astars がある場合、language support は次を行える。
+
+- parser-specific behavior を adapter に閉じ込められる
+- source mapping と query primitive を再利用できる
+- core engine shape が Python 以外でも成立するか検証できる
+- downstream package が追加言語を段階的に採用できる
+
+Astars は、reference path が安定する前に広い language coverage を約束しない。代わりに、language expansion のための明確な道筋を提供する。
+
+## Practical Engineering Use Cases
+
+実務では、Astars は社内の code understanding、review、migration、governance、LLM-assisted development tool のための共通 engine として使える。
+
+### Metrics / Structural Statistics
+
+Downstream package: `astars-metrics`
+
+Astars がない場合、metrics package は source の parse、node normalization、tree traversal、finding と source location の対応づけを自前で決める必要がある。
+
+Astars がある場合、metrics package は metric definition に集中できる。
+
+- 安定した node interface を通じて function、class、branch、expression を数えられる
+- metric location を source span として report できる
+- parser-specific node API への直接依存を避けられる
+- 他の `astars-*` package と同じ parse/query workflow を再利用できる
+
+Astars は metric を定義しない。metric を計算するための構造を提供する。
+
+### Code Review / Quality Signals
+
+Downstream package: `astars-code-review`
+
+review-oriented tool では、source region を特定し、finding を説明し、正確な line や span に comment を紐づける必要がある。
+
+Astars がある場合、review package は次を行える。
+
+- node から source span に finding を戻せる
+- pull request の structural change を要約できる
+- parser setup を自前で持たずに review comment を作れる
+- structural query と repository-specific policy を組み合わせられる
+- review decision を engine の外に保てる
+
+Astars は、ある pattern に review comment を出すべきか判断しない。downstream package が relevant code を特定し説明しやすくする。
+
+### Migration / Refactoring Support
+
+Downstream package: internal migration tools または `astars-migrate`
+
+開発チームでは、deprecated API の検出、framework usage の更新、semi-automatic code modernization などが必要になることがある。
+
+Astars がある場合、migration package は次を行える。
+
+- structural query を通じて古い API call を検出できる
+- replacement を正確な source span に対応づけられる
+- generic transformation primitive で edit plan を作れる
+- migration recipe を engine の外に保てる
+
+Astars は migration recipe を所有しない。recipe package が使える source-aware structure と edit を提供する。
+
+### Architecture / Dependency Rule Checks
+
+Downstream package: internal governance tools
+
+大規模 repository では、layer boundary、forbidden import、team-specific dependency rule の検査が必要になることがある。
+
+Astars がある場合、governance package は次を行える。
+
+- import、class definition、call site を構造的に inspect できる
+- violation を source span に紐づけて report できる
+- code structure と repository ownership metadata を組み合わせられる
+- organization-specific policy を engine の外に保てる
+
+Astars は architecture policy を定義しない。policy package が評価できる structural fact を提供する。
+
+### LLM Coding Assistant Context
+
+Downstream package: internal assistant tooling または `astars-llm-context`
+
+LLM coding workflow では、ファイル全体ではなく、function、class、import、近傍の structural region に基づいて context を取り出したいことがある。
+
+Astars がある場合、assistant package は次を行える。
+
+- mapped program structure に基づいて source を slice できる
+- prompt context の provenance を保持できる
+- 関連する function や class を一貫して取得できる
+- generated code を同じ engine surface で inspect できる
+
+Astars は assistant そのものではない。assistant tool のための source-faithful structure を提供する。
+
+### Test Impact / Change Summaries
+
+Downstream package: CI tooling または repository automation
+
+開発チームでは、pull request でどの function、class、public interface が変わったかを把握したいことがある。
+
+Astars がある場合、automation は次を行える。
+
+- file diff を changed program node に対応づけられる
+- structural change summary を生成できる
+- downstream heuristic を使って関連 test を提案できる
+- summary や finding を正確な source span に紐づけられる
+
+Astars はどの test を必ず実行するべきか判断しない。CI tool が利用できる structural change data を提供する。
+
+### Visualization / Exploration
+
+Downstream package: `astars-visualizer`
+
+visualization tool は structure、label、source position を必要とするが、parser integration を自前で持つ必要はない。
+
+Astars がある場合、visualizer は次を行える。
+
+- 安定した node interface を通じて AST-like structure を描画できる
+- 選択された node に対応する source range を highlight できる
+- source、syntax node、AST node の mapping を可視化できる
+- analysis-specific package から独立したまま実装できる
+
+Astars は visualization product にならない。visualization を可能にする data model を提供する。


### PR DESCRIPTION
## 概要

Astars を軽量な program structure engine として整理していくための日本語版戦略ドキュメントを追加しました。

このブランチでは、Astars の位置づけ、想定ユースケース、概念モデル、API 方針、アーキテクチャ、移行計画を整理し、今後の実装判断の基準を文書化しています。

## 追加・更新内容

- Astars の上位戦略を整理
- Research / Practical のユースケースを整理
- `SourceText`, `SourceSpan`, `RawSyntaxNode`, `AST`, `CST`, `SyntaxGraph`, `SourceUnit` などの概念モデルを定義
- v0 で最初に固定する public API 方針を整理
- engine / operations / language support / adapter の責務境界を整理
- 現行実装から目標アーキテクチャへ移行するための段階的な計画を追加
- 今後必要なドキュメント計画とロードマップを追加

## 意図

Astars は、metrics や code review などの個別ツールではなく、それらの下支えになる program structure engine として位置づけます。

特に、AST-like structure を扱いやすくしつつ、node から元 source span / source text に戻れることを中核価値として整理しています。

## テスト

ドキュメントのみの変更のため、テストは実行していません。