### PR TITLE
Add release checklist tooling

### DIFF
--- a/checkPypi.sh
+++ b/checkPypi.sh
@@ -1,3 +1,9 @@
-python3 setup.py sdist
-python3 setup.py bdist_wheel
-twine check dist/*
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON="${PYTHON:-python3}"
+
+rm -rf build dist astars.egg-info
+
+"${PYTHON}" -m build --sdist --wheel
+"${PYTHON}" -m twine check dist/*

--- a/docs/RELEASE_STRATEGY.ja.md
+++ b/docs/RELEASE_STRATEGY.ja.md
@@ -365,6 +365,82 @@ release 前 checklist:
 - [ ] TestPyPI から install して smoke test が通る
 - [ ] PyPI publish 対象の artifact が release tag 由来である
 
+## Clean Install Checklist
+
+release branch 上で、local working tree ではなく build artifact から install できることを確認する。
+
+release tool を用意する。
+
+```bash
+python3 -m pip install -e ".[release]"
+```
+
+artifact を作る。
+
+```bash
+./checkPypi.sh
+```
+
+clean venv に wheel を install して smoke test する。
+
+```bash
+python3 -m venv /private/tmp/astars-clean-install
+/private/tmp/astars-clean-install/bin/python -m pip install --upgrade pip
+/private/tmp/astars-clean-install/bin/python -m pip install dist/*.whl
+/private/tmp/astars-clean-install/bin/python - <<'PY'
+import astars
+
+unit = astars.parse_str("def hello(name):\n    return name\n", lang="python")
+assert unit.root.kind == "Module"
+assert unit.find(kind="FunctionDef")
+assert unit.source_of(unit.find(kind="FunctionDef")[0]).startswith("def hello")
+print(astars.__version__)
+PY
+```
+
+## TestPyPI Checklist
+
+TestPyPI には release candidate を upload する。TestPyPI では runtime dependency が揃わないことがあるため、install 検証では PyPI 本番を dependency index として併用する。
+
+前提:
+
+- release candidate tag または release branch 由来の artifact を使う
+- TestPyPI に既に存在する version は再利用しない
+- 本番予定 version を雑に TestPyPI へ上げない
+
+TestPyPI に upload する。
+
+```bash
+./checkPypi.sh
+./registPypi.sh testpypi
+```
+
+TestPyPI から clean venv に install して smoke test する。
+
+```bash
+ASTARS_VERSION=0.1.0rc1
+python3 -m venv /private/tmp/astars-testpypi-install
+/private/tmp/astars-testpypi-install/bin/python -m pip install --upgrade pip
+/private/tmp/astars-testpypi-install/bin/python -m pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  "astars==${ASTARS_VERSION}"
+/private/tmp/astars-testpypi-install/bin/python - <<'PY'
+import astars
+
+unit = astars.parse_str("def hello(name):\n    return name\n", lang="python")
+assert unit.root.kind == "Module"
+assert unit.find(kind="FunctionDef")
+print(astars.__version__)
+PY
+```
+
+本番 PyPI への upload は、TestPyPI install smoke test が通った後に行う。
+
+```bash
+./registPypi.sh pypi
+```
+
 ## Do Not Do
 
 避けること:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=61",
+  "setuptools>=77",
   "wheel",
   "setuptools_scm[toml]>=7"
 ]
@@ -14,7 +14,7 @@ dynamic = ["version"]
 authors = [
   { name = "Wakana Hashimoto", email = "oxwasouxo@gmail.com" },
 ]
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
   "anytree",
@@ -25,7 +25,6 @@ classifiers = [
   "Development Status :: 2 - Pre-Alpha",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -37,6 +36,10 @@ classifiers = [
 [project.optional-dependencies]
 test = [
   "pytest",
+]
+release = [
+  "build",
+  "twine",
 ]
 
 [project.urls]

--- a/registPypi.sh
+++ b/registPypi.sh
@@ -1,6 +1,18 @@
-rm -rf build/ dist/ astars.egg-ingo/
+#!/usr/bin/env bash
+set -euo pipefail
 
-python3 setup.py bdist_wheel
+PYTHON="${PYTHON:-python3}"
+repository="${1:-}"
 
-twine upload --repository testpypi dist/*
-twine upload --repository pypi dist/*
+if [[ "${repository}" != "testpypi" && "${repository}" != "pypi" ]]; then
+  echo "Usage: $0 testpypi|pypi" >&2
+  exit 2
+fi
+
+if ! compgen -G "dist/*" > /dev/null; then
+  echo "dist/ is empty. Run ./checkPypi.sh first." >&2
+  exit 1
+fi
+
+"${PYTHON}" -m twine check dist/*
+"${PYTHON}" -m twine upload --repository "${repository}" dist/*


### PR DESCRIPTION
## Summary

This PR updates the release preparation workflow for the new `pyproject.toml`-based packaging setup.

Main changes:

- Replace legacy `setup.py`-based package check script with `python -m build`.
- Update publish helper to require an explicit target:
  - `./registPypi.sh testpypi`
  - `./registPypi.sh pypi`
- Add `release` optional dependency group with:
  - `build`
  - `twine`
- Update package license metadata to SPDX-style `license = "MIT"`.
- Add clean install and TestPyPI verification steps to `RELEASE_STRATEGY.ja.md`.

## Verification

- `bash -n checkPypi.sh`
- `bash -n registPypi.sh`
- `env PYTHON=/private/tmp/astars-release-tools/bin/python ./checkPypi.sh`
- Installed generated wheel into a clean venv and smoke-tested:
  - `import astars`
  - `astars.parse_str(..., lang="python")`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

## Notes

Actual TestPyPI upload was not performed in this PR.